### PR TITLE
Update theme provider to default to dark mode and clean up vercel.jso…

### DIFF
--- a/lib/config/theme_provider.dart
+++ b/lib/config/theme_provider.dart
@@ -4,7 +4,7 @@ import 'palette.dart';
 
 class ThemeProvider extends ChangeNotifier {
   static const String _themeKey = 'theme_mode';
-  bool _isDarkMode = false;
+  bool _isDarkMode = true; // Default to dark mode
 
   bool get isDarkMode => _isDarkMode;
 
@@ -14,7 +14,7 @@ class ThemeProvider extends ChangeNotifier {
 
   Future<void> _loadThemeMode() async {
     final prefs = await SharedPreferences.getInstance();
-    _isDarkMode = prefs.getBool(_themeKey) ?? false;
+    _isDarkMode = prefs.getBool(_themeKey) ?? true; // Default to dark mode
     notifyListeners();
   }
 

--- a/lib/widgets/responsive_search_bar.dart
+++ b/lib/widgets/responsive_search_bar.dart
@@ -57,7 +57,6 @@ class _ResponsiveSearchBarState extends State<ResponsiveSearchBar> {
     final themeProvider = Provider.of<ThemeProvider>(context);
     final isDark = themeProvider.isDarkMode;
     final isMobile = ResponsiveHelper.isMobile(context);
-    final isTablet = ResponsiveHelper.isTablet(context);
     
     return Container(
       decoration: BoxDecoration(

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,5 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "build/web/**",
-      "use": "@vercel/static"
-    }
-  ],
   "routes": [
     {
       "src": "/(.*)",


### PR DESCRIPTION
…n configuration

Change the default theme mode in ThemeProvider to dark mode and adjust the theme loading logic accordingly. Additionally, remove the static builds configuration from vercel.json to streamline deployment settings.