### PR TITLE
Implement RLS compliance for quota target updates

### DIFF
--- a/lib/screen/main_pages/reports_pages/reports_content.dart
+++ b/lib/screen/main_pages/reports_pages/reports_content.dart
@@ -12,6 +12,7 @@ import 'package:pasada_admin_application/services/quota_service.dart';
 import 'package:pasada_admin_application/widgets/quota/quota_bento_grid.dart';
 import 'package:pasada_admin_application/widgets/quota/quota_edit_dialog.dart';
 import 'package:pasada_admin_application/widgets/quota/quota_update_dialog.dart';
+import 'package:pasada_admin_application/services/auth_service.dart';
 
 class ReportsContent extends StatefulWidget {
   final Function(String, {Map<String, dynamic>? args})? onNavigateToPage;
@@ -465,13 +466,19 @@ class _ReportsContentState extends State<ReportsContent> {
   }) async {
     try {
       debugPrint('[ReportsContent._saveQuotaTargets] saving for driverId=$driverId daily=$daily weekly=$weekly monthly=$monthly total=$total');
+      // Ensure we have the current admin id for RLS-compliant writes
+      int? adminId = AuthService().currentAdminID;
+      if (adminId == null) {
+        await AuthService().loadAdminID();
+        adminId = AuthService().currentAdminID;
+      }
       await QuotaService.saveGlobalQuotaTargets(
         supabase,
         daily: daily,
         weekly: weekly,
         monthly: monthly,
         total: total,
-        createdByAdminId: null,
+        createdByAdminId: adminId,
         driverId: driverId,
       );
 

--- a/lib/services/quota_service.dart
+++ b/lib/services/quota_service.dart
@@ -97,6 +97,10 @@ class QuotaService {
         .from(tableName)
         .update({'is_active': false, 'updated_at': DateTime.now().toIso8601String()})
         .eq('is_active', true);
+    // If RLS restricts updates to rows created by the same admin, include that filter
+    if (createdByAdminId != null) {
+      updateQuery.eq('created_by', createdByAdminId);
+    }
     if (driverId == null) {
       // Use generic filter with 'is' operator for NULL
       updateQuery.filter('driver_id', 'is', null);


### PR DESCRIPTION
- Added authentication service to retrieve the current admin ID for RLS-compliant writes.
- Updated quota target saving logic to include the admin ID when saving global quota targets.
- Enhanced update query in QuotaService to filter updates based on the admin who created the records, ensuring proper access control.