### PR TITLE
Refactor theme and dropdown initialization in various components

### DIFF
--- a/lib/screen/appbars_&_drawer/drawer.dart
+++ b/lib/screen/appbars_&_drawer/drawer.dart
@@ -625,7 +625,7 @@ class _MyDrawerState extends State<MyDrawer> with TickerProviderStateMixin {
                                 onChanged: (value) {
                                   themeProvider.toggleTheme();
                                 },
-                                activeColor: Colors.white,
+                                activeThumbColor: Colors.white,
                                 activeTrackColor: Palette.lightPrimary,
                                 inactiveThumbColor: isDark ? Palette.darkTextSecondary : Palette.lightTextSecondary,
                                 inactiveTrackColor: isDark ? Palette.darkBorder : Palette.lightBorder,

--- a/lib/screen/main_pages/fleet_pages/edit_route_dialog.dart
+++ b/lib/screen/main_pages/fleet_pages/edit_route_dialog.dart
@@ -348,7 +348,7 @@ class _EditRouteDialogState extends State<EditRouteDialog> {
             ),
           ),
           child: DropdownButtonFormField<String>(
-            value: _selectedStatus,
+            initialValue: _selectedStatus,
             decoration: InputDecoration(
               border: InputBorder.none,
               contentPadding: EdgeInsets.symmetric(

--- a/lib/screen/main_pages/reports_pages/database_tables/route_tables/edit_route_dialog.dart
+++ b/lib/screen/main_pages/reports_pages/database_tables/route_tables/edit_route_dialog.dart
@@ -344,7 +344,7 @@ class _EditRouteDialogState extends State<EditRouteDialog> {
                           contentPadding: EdgeInsets.symmetric(
                               vertical: 12.0, horizontal: 16.0),
                         ),
-                        value: _status,
+                        initialValue: _status,
                         items: ['Active', 'Processing', 'Inactive']
                             .map((String status) {
                           return DropdownMenuItem<String>(

--- a/lib/screen/settings_pages/settings_utils.dart
+++ b/lib/screen/settings_pages/settings_utils.dart
@@ -50,7 +50,7 @@ class SwitchTile extends StatelessWidget {
           Switch(
             value: value,
             onChanged: onChanged,
-            activeColor: Palette.greenColor,
+            activeThumbColor: Palette.greenColor,
           ),
         ],
       ),

--- a/lib/widgets/quota/quota_edit_dialog.dart
+++ b/lib/widgets/quota/quota_edit_dialog.dart
@@ -92,7 +92,7 @@ Future<void> showQuotaEditDialog({
                   ),
                   const SizedBox(height: 6),
                   DropdownButtonFormField<int?> (
-                    value: selectedDriverId,
+                    initialValue: selectedDriverId,
                     items: [
                       const DropdownMenuItem<int?>(value: null, child: Text('All drivers (Global)')),
                       ...drivers.map((d) => DropdownMenuItem<int?>(

--- a/lib/widgets/quota/quota_update_dialog.dart
+++ b/lib/widgets/quota/quota_update_dialog.dart
@@ -86,7 +86,7 @@ Future<void> showQuotaUpdateDialog({
                   ),
                   const SizedBox(height: 6),
                   DropdownButtonFormField<int?> (
-                    value: selectedDriverId,
+                    initialValue: selectedDriverId,
                     items: [
                       const DropdownMenuItem<int?>(value: null, child: Text('All drivers (Global)')),
                       ...drivers.map((d) => DropdownMenuItem<int?> (


### PR DESCRIPTION
- Updated `activeColor` to `activeThumbColor` in `drawer.dart` and `settings_utils.dart` for consistency in theme handling.
- Changed `value` to `initialValue` in multiple `DropdownButtonFormField` instances across `edit_route_dialog.dart`, `quota_edit_dialog.dart`, and `quota_update_dialog.dart` to ensure proper initialization of dropdown values.
- Removed the flutter subproject reference as it is no longer needed.